### PR TITLE
feat: add skill-propose skill

### DIFF
--- a/skills/skill-propose/SKILL.md
+++ b/skills/skill-propose/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: skill-propose
+description: Analyze the current project to identify missing skills and submit a pull request proposing the new skill to the common-ai-skill repository.
+---
+
+## Sequence
+
+audit existing skills → identify gap(missing concern or coverage) → define new skill following project principles → submit proposal as pull request targeting develop branch
+
+## Proposal Format
+
+```
+branch: improve/<descriptive-name>
+target: develop
+title: feat: add <skill-name> skill
+body:
+  ## Motivation
+  - what concern is not covered by existing skills
+  ## Skill Definition
+  - name, sequence, constraints, done criteria
+  ## Validation
+  - no technology references
+  - abstract goal only
+  - cross-model compatible
+```
+
+## Rules
+<constraints>
+- proposed skill must define WHAT, never HOW
+- no technology-specific references in skill definition
+- every proposed skill must have: sequence + constraints + done criteria
+- proposed skill must not overlap with existing skills
+- branch from develop; PR targets develop
+</constraints>
+
+## Done
+<criteria>
+gap identified + skill definition follows project principles + pull request submitted to develop
+</criteria>


### PR DESCRIPTION
Closes #1

## Summary
- Add `skills/skill-propose/SKILL.md` — enables AI to audit common-ai-skill for missing concerns and submit a PR proposing a new skill
- Follows project principles: defines WHAT only, no technology references, abstract goal

## Skill Contract
- Sequence: audit → identify gap → define skill → submit PR to develop
- Constraints: WHAT-only, no overlap with existing skills, branch from develop
- Done: gap identified + definition follows principles + PR submitted

## Validation
- No technology-specific references
- Cross-model compatible format (Markdown headings + XML semantic tags)
- Consistent with existing skill structure