### PR TITLE
feat: add skill-install skill

### DIFF
--- a/skills/skill-install/SKILL.md
+++ b/skills/skill-install/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: skill-install
+description: Detect which common-ai-skill skills the current project needs and wire them in using the project's available installation method.
+---
+
+## Sequence
+
+detect project context(architecture, concerns, existing tooling) → select required skills from common-ai-skill catalog → detect available installation method → install selected skills → verify skills are loadable
+
+## Selection Criteria
+
+```
+code changes present       → delivery-workflow
+layered architecture       → hexagonal-development
+abstraction boundaries     → interface-first-development
+AI model integration       → framework-selection + observability
+retrieval pipeline         → rag-development
+quality measurement        → evaluation
+irreversible actions       → human-in-the-loop
+multi-agent coordination   → agent-orchestration
+explicit request           → version | security-audit | principle-audit | ai-token-optimize | coverage | docs-sync
+```
+
+## Installation Methods
+
+detect in order: package manager config → submodule config → manual copy → report if none available
+
+## Rules
+<constraints>
+- detect project conventions before selecting skills
+- do not install skills that are already present and up to date
+- do not install skills that are irrelevant to the project context
+- installation must be idempotent
+- verify each installed skill is loadable after installation
+</constraints>
+
+## Done
+<criteria>
+required skills identified + installed via available method + each skill verified loadable
+</criteria>


### PR DESCRIPTION
Closes #2

## Summary
- Add `skills/skill-install/SKILL.md` — enables AI to detect which skills a project needs and install them via the available method
- Follows project principles: defines WHAT only, no technology references, abstract goal

## Skill Contract
- Sequence: detect context → select skills → detect install method → install → verify
- Selection criteria maps project concerns to relevant skills
- Constraints: idempotent, no irrelevant installs, verify after install
- Done: skills identified + installed + verified loadable

## Validation
- No technology-specific references
- Cross-model compatible format
- Consistent with existing skill structure