### PR TITLE
feat: add skill-update skill

### DIFF
--- a/skills/skill-update/SKILL.md
+++ b/skills/skill-update/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: skill-update
+description: Detect the currently installed version of common-ai-skill, check for a newer release, and update all installed skills to the latest version.
+---
+
+## Sequence
+
+detect installation method → detect installed version → fetch latest release version → compare versions → if update available: update via detected method → verify all skills present and non-empty → report result
+
+## Version Detection
+
+detect in order: package manager lock file → submodule ref → installed SKILL.md metadata → report unknown if none found
+
+## Update Methods
+
+match detected installation method:
+- package manager → update via package manager
+- submodule → pull latest ref
+- manual copy → re-run installer with latest source
+
+## Rules
+<constraints>
+- detect installation method before attempting update
+- do not update if already at latest version
+- update must be atomic — all skills updated together, never partial
+- verify every skill is present and non-empty after update
+- if update fails, restore previous state and report error
+- report installed version, latest version, and list of changed skills
+</constraints>
+
+## Done
+<criteria>
+installed version detected + latest version fetched + update applied if needed + all skills verified + result reported
+</criteria>


### PR DESCRIPTION
Closes #3

## Summary
- Add `skills/skill-update/SKILL.md` — enables AI to detect installed version, check for newer releases, and update all skills atomically
- Follows project principles: defines WHAT only, no technology references, abstract goal

## Skill Contract
- Sequence: detect method → detect version → fetch latest → compare → update → verify → report
- Constraints: atomic update, restore on failure, no-op if already latest
- Done: version detected + update applied if needed + all skills verified

## Validation
- No technology-specific references
- Cross-model compatible format
- Consistent with existing skill structure