### PR TITLE
feat: add harness-engineering skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ change.type=ai-feature
   + evaluation              (quality measurement needed)
   + human-in-the-loop       (action.risk=irreversible)
   + agent-orchestration     (ai.complexity=multi-agent)
+  + harness-engineering     (agent runtime design, guardrails, or sandboxing involved)
 
 change.type=explicit
   → /version /security-audit /principle-audit /ai-token-optimize
@@ -552,6 +553,140 @@ map-reduce   → split input, process independently, reduce
 **Done**
 <criteria>
 agents communicate only via orchestrator + messages serializable + failures handled + depth bounded + correlation IDs present
+</criteria>
+
+---
+
+### harness-engineering
+> Design the runtime environment around AI agents — constraints, guardrails, verification, sandboxing, feedback loops, and recovery mechanisms that make agents reliable at scale.
+
+**Sequence**
+
+define agent boundaries → design guardrails → configure sandboxing → build verification pipeline → implement feedback loops → add recovery mechanisms → set up session continuity → validate end-to-end
+
+**Layers**
+
+```
+context management     → what the agent sees (repo-local, versioned artifacts only)
+permission boundary    → what the agent can access (files, tools, commands)
+execution sandbox      → where the agent runs (isolated, rollback-capable)
+validation pipeline    → how outputs are verified (deterministic + semantic)
+architectural guard    → structural rules the agent must not violate
+feedback loop          → how failures inform next attempts
+recovery mechanism     → how the system handles and corrects errors
+session continuity     → how state bridges across context resets
+```
+
+**Architectural Constraints**
+
+```
+deps flow: types → config → repository → service → runtime → presentation
+structural tests validate layer compliance automatically
+agent cannot bypass constraints — enforcement is mechanical, not instructional
+```
+
+**Context Strategy**
+
+```
+repository-centered  → all agent-accessible knowledge lives in versioned artifacts
+map over manual      → concise pointers, not exhaustive instructions
+scoped context       → load only what the current task requires
+knowledge promotion  → external knowledge → repo artifact before agent use
+adaptive compaction  → progressively reduce older observations to preserve recent context
+```
+
+**Verification Tiers**
+
+```
+deterministic   → static analysis, structural tests, schema validation
+semantic        → model-based correctness, intent alignment, output quality
+composite       → deterministic first (fast, cheap), semantic second (nuanced)
+generator-evaluator → separate generation from evaluation in adversarial loop
+```
+
+**Risk-Based Routing**
+
+```
+low risk    → automated validation only, no human gate
+medium risk → automated validation + async human review
+high risk   → halt until explicit human approval before execution
+```
+
+**Session Continuity**
+
+```
+progress artifact    → structured file tracking completed work and next steps
+initializer session  → first run sets up environment and initial state
+incremental session  → subsequent runs read progress, advance, update artifact
+context reset        → clear context between sessions to prevent drift
+automatic compaction → compress history when context limit approaches
+```
+
+**Agent Topology**
+
+```
+single agent         → one agent handles full task (prefer when sufficient)
+plan-execute split   → one agent plans, another executes (reduce reasoning load)
+generator-evaluator  → one agent produces, another critiques in adversarial loop
+specialist routing   → classify input, dispatch to domain-specific agent
+```
+
+**Trace-Driven Improvement**
+
+```
+capture  → log every tool call, decision, and intermediate output
+analyze  → cluster failure patterns across runs
+detect   → identify doom loops (repeated edits to same target without progress)
+convert  → turn recurring failure patterns into new constraints or middleware
+```
+
+**Harness Evolution**
+
+```
+each harness component encodes an assumption about model limitations
+when models improve → re-test assumptions → strip what is no longer needed
+prefer removing complexity over adding it — simplification beats sophistication
+harness must remain model-agnostic — swappable without structural changes
+```
+
+**Rules**
+<constraints>
+- enforce constraints mechanically — never rely solely on prompt instructions for safety
+- every agent action must be auditable — log inputs, outputs, tool calls, and decisions
+- sandbox must support rollback — no irreversible side effects without explicit approval
+- permission boundaries must follow least-privilege — grant minimum access required per task
+- context is a scarce resource — provide maps, not manuals; pointers, not payloads
+- architectural boundaries must be enforced by structural tests, not by convention
+- verification must combine deterministic and semantic checks — neither alone is sufficient
+- feedback from failures must be converted into reusable constraints — not one-off fixes
+- recovery must be automatic for known failure classes, escalated for unknown ones
+- agent-generated artifacts must pass the same quality gates as human-generated ones
+- periodic maintenance agents must detect drift in docs, architecture, and constraints
+- long-running tasks must persist progress in structured artifacts across sessions
+- detect doom loops via trace analysis — intervene when repeated attempts show no progress
+- route actions through risk tiers — high-risk actions require human approval
+- prefer single-agent topology — escalate to multi-agent only when single agent is insufficient
+- harness must survive model changes — no coupling to specific model capabilities
+- evaluator must be adversarial — optimistic self-review is insufficient for quality
+</constraints>
+
+**Anti-Patterns**
+
+```
+prompt-only safety       → relying on instructions instead of mechanical enforcement
+unbounded context        → dumping all docs into context instead of targeted selection
+trust-by-default         → granting full access instead of least-privilege boundaries
+manual-only review       → human review as sole quality gate instead of automated verification
+fix-and-forget           → patching individual failures instead of creating reusable constraints
+optimistic self-eval     → agent evaluating own work without adversarial challenge
+model-coupled harness    → harness assumptions hardcoded to specific model behavior
+session amnesia          → no structured handoff between context windows
+complexity accumulation  → adding harness components without re-testing necessity
+```
+
+**Done**
+<criteria>
+permission boundaries enforced + execution sandboxed with rollback + verification pipeline active (deterministic + semantic + generator-evaluator) + architectural constraints mechanically enforced + feedback loops convert failures to constraints + all agent outputs pass same quality gates as human outputs + audit trail present for all agent actions + session continuity via progress artifacts + doom loop detection active + risk-based routing configured + harness components documented
 </criteria>
 
 ---

--- a/ai_skill_interface/install.py
+++ b/ai_skill_interface/install.py
@@ -21,6 +21,7 @@ SKILLS = [
     "evaluation",
     "human-in-the-loop",
     "agent-orchestration",
+    "harness-engineering",
     "auto-select",
 ]
 

--- a/bin/init.js
+++ b/bin/init.js
@@ -25,6 +25,7 @@ const SKILLS = [
   "evaluation",
   "human-in-the-loop",
   "agent-orchestration",
+  "harness-engineering",
   "auto-select",
 ];
 

--- a/skills/auto-select/SKILL.md
+++ b/skills/auto-select/SKILL.md
@@ -42,6 +42,7 @@ change.type=ai-feature
   + evaluation              (quality measurement needed)
   + human-in-the-loop       (action.risk=irreversible)
   + agent-orchestration     (ai.complexity=multi-agent)
+  + harness-engineering     (agent runtime design, guardrails, or sandboxing involved)
 
 change.type=explicit
   → the skill the user named directly

--- a/skills/harness-engineering/SKILL.md
+++ b/skills/harness-engineering/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: harness-engineering
+description: Design the runtime environment around AI agents — constraints, guardrails, verification, sandboxing, feedback loops, and recovery mechanisms that make agents reliable at scale.
+requires: [framework-selection, observability]
+---
+
+## Sequence
+
+define agent boundaries → design guardrails → configure sandboxing → build verification pipeline → implement feedback loops → add recovery mechanisms → set up session continuity → validate end-to-end
+
+## Layers
+
+```
+context management     → what the agent sees (repo-local, versioned artifacts only)
+permission boundary    → what the agent can access (files, tools, commands)
+execution sandbox      → where the agent runs (isolated, rollback-capable)
+validation pipeline    → how outputs are verified (deterministic + semantic)
+architectural guard    → structural rules the agent must not violate
+feedback loop          → how failures inform next attempts
+recovery mechanism     → how the system handles and corrects errors
+session continuity     → how state bridges across context resets
+```
+
+## Architectural Constraints
+
+```
+deps flow: types → config → repository → service → runtime → presentation
+structural tests validate layer compliance automatically
+agent cannot bypass constraints — enforcement is mechanical, not instructional
+```
+
+## Context Strategy
+
+```
+repository-centered  → all agent-accessible knowledge lives in versioned artifacts
+map over manual      → concise pointers, not exhaustive instructions
+scoped context       → load only what the current task requires
+knowledge promotion  → external knowledge → repo artifact before agent use
+adaptive compaction  → progressively reduce older observations to preserve recent context
+```
+
+## Verification Tiers
+
+```
+deterministic   → static analysis, structural tests, schema validation
+semantic        → model-based correctness, intent alignment, output quality
+composite       → deterministic first (fast, cheap), semantic second (nuanced)
+generator-evaluator → separate generation from evaluation in adversarial loop
+```
+
+## Risk-Based Routing
+
+```
+low risk    → automated validation only, no human gate
+medium risk → automated validation + async human review
+high risk   → halt until explicit human approval before execution
+```
+
+## Session Continuity
+
+```
+progress artifact    → structured file tracking completed work and next steps
+initializer session  → first run sets up environment and initial state
+incremental session  → subsequent runs read progress, advance, update artifact
+context reset        → clear context between sessions to prevent drift
+automatic compaction → compress history when context limit approaches
+```
+
+## Agent Topology
+
+```
+single agent         → one agent handles full task (prefer when sufficient)
+plan-execute split   → one agent plans, another executes (reduce reasoning load)
+generator-evaluator  → one agent produces, another critiques in adversarial loop
+specialist routing   → classify input, dispatch to domain-specific agent
+```
+
+## Trace-Driven Improvement
+
+```
+capture  → log every tool call, decision, and intermediate output
+analyze  → cluster failure patterns across runs
+detect   → identify doom loops (repeated edits to same target without progress)
+convert  → turn recurring failure patterns into new constraints or middleware
+```
+
+## Harness Evolution
+
+```
+each harness component encodes an assumption about model limitations
+when models improve → re-test assumptions → strip what is no longer needed
+prefer removing complexity over adding it — simplification beats sophistication
+harness must remain model-agnostic — swappable without structural changes
+```
+
+## Rules
+
+<constraints>
+- enforce constraints mechanically — never rely solely on prompt instructions for safety
+- every agent action must be auditable — log inputs, outputs, tool calls, and decisions
+- sandbox must support rollback — no irreversible side effects without explicit approval
+- permission boundaries must follow least-privilege — grant minimum access required per task
+- context is a scarce resource — provide maps, not manuals; pointers, not payloads
+- architectural boundaries must be enforced by structural tests, not by convention
+- verification must combine deterministic and semantic checks — neither alone is sufficient
+- feedback from failures must be converted into reusable constraints — not one-off fixes
+- recovery must be automatic for known failure classes, escalated for unknown ones
+- agent-generated artifacts must pass the same quality gates as human-generated ones
+- periodic maintenance agents must detect drift in docs, architecture, and constraints
+- long-running tasks must persist progress in structured artifacts across sessions
+- detect doom loops via trace analysis — intervene when repeated attempts show no progress
+- route actions through risk tiers — high-risk actions require human approval
+- prefer single-agent topology — escalate to multi-agent only when single agent is insufficient
+- harness must survive model changes — no coupling to specific model capabilities
+- evaluator must be adversarial — optimistic self-review is insufficient for quality
+</constraints>
+
+## Anti-Patterns
+
+```
+prompt-only safety       → relying on instructions instead of mechanical enforcement
+unbounded context        → dumping all docs into context instead of targeted selection
+trust-by-default         → granting full access instead of least-privilege boundaries
+manual-only review       → human review as sole quality gate instead of automated verification
+fix-and-forget           → patching individual failures instead of creating reusable constraints
+optimistic self-eval     → agent evaluating own work without adversarial challenge
+model-coupled harness    → harness assumptions hardcoded to specific model behavior
+session amnesia          → no structured handoff between context windows
+complexity accumulation  → adding harness components without re-testing necessity
+```
+
+## Done
+
+<criteria>
+permission boundaries enforced + execution sandboxed with rollback + verification pipeline active (deterministic + semantic + generator-evaluator) + architectural constraints mechanically enforced + feedback loops convert failures to constraints + all agent outputs pass same quality gates as human outputs + audit trail present for all agent actions + session continuity via progress artifacts + doom loop detection active + risk-based routing configured + harness components documented
+</criteria>


### PR DESCRIPTION
## Summary

- Add `harness-engineering` skill — AI 에이전트 런타임 환경 설계를 위한 새 스킬
- 최신 연구 및 논문 기반으로 설계:
  - **OpenAI** — Codex 하네스 엔지니어링 (100만 줄, 수동 코드 0줄, ~10x 속도)
  - **Anthropic** — 장기 실행 에이전트 하네스 설계, GAN 영감 generator-evaluator 루프
  - **LangChain** — Deep Agents SDK, 하네스만 변경으로 Terminal Bench 2.0 52.8%→66.5%
  - **OPENDEV** (arXiv:2603.05344) — 이중 에이전트 아키텍처, adaptive context compaction
  - **Manus** — 5회 아키텍처 재작성, 복잡성 제거가 성능 향상의 핵심
  - **HARNESSCARD** 프리프린트 — 하네스 문서화 표준 제안
  - **Philipp Schmid** — 모델 드리프트 감지, 경량 하네스 원칙

### 스킬 구성 요소
- **8개 레이어**: context management → permission boundary → execution sandbox → validation pipeline → architectural guard → feedback loop → recovery mechanism → session continuity
- **검증 4단계**: deterministic → semantic → composite → generator-evaluator
- **위험 기반 라우팅**: low/medium/high risk 계층화
- **세션 연속성**: progress artifact, initializer/incremental session, context reset
- **에이전트 토폴로지**: single agent, plan-execute split, generator-evaluator, specialist routing
- **트레이스 기반 개선**: capture → analyze → detect doom loops → convert to constraints
- **하네스 진화 원칙**: 모델 개선 시 가정 재검증, 복잡성 제거 우선
- **16개 규칙**, **9개 안티패턴**

### 변경 파일
| 파일 | 변경 |
|------|------|
| `skills/harness-engineering/SKILL.md` | 새 스킬 파일 |
| `bin/init.js` | 스킬 목록 추가 |
| `ai_skill_interface/install.py` | ��킬 목록 추가 |
| `skills/auto-select/SKILL.md` | 자동 선택 규칙 추가 |
| `README.md` | 스킬 정의 + 자동 선택 규칙 동기화 |

## Test plan

- [ ] `npx ai-skill-interface` 실행 후 `~/.claude/skills/harness-engineering/SKILL.md` 설치 확인
- [ ] `pip install . && ai-skill-interface` 실행 후 설치 확인
- [ ] 스킬 프론트매터 의존성 (`requires: [framework-selection, observability]`) 해석 확인
- [ ] auto-select에서 agent runtime/guardrails/sandboxing 관련 작업 시 자동 선택 확인
- [ ] 기술 특정 참조 없음 (zero technology references) 검증
- [ ] README.md와 SKILL.md 내용 동기화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)