### PR TITLE
feat: support multiple AI agents in init — Cursor, Windsurf, Copilot, Cline

### DIFF
--- a/ai_skill_interface/install.py
+++ b/ai_skill_interface/install.py
@@ -1,6 +1,7 @@
 import shutil
 import sys
 from pathlib import Path
+from typing import Callable
 
 SKILLS = [
     "delivery-workflow",
@@ -23,6 +24,47 @@ SKILLS = [
     "harness-engineering",
     "auto-select",
 ]
+
+# Agent configs: each defines how to write the auto-select entry point.
+# claude uses @import; others inline the skill content (no import support).
+AGENTS = [
+    {
+        "name": "claude",
+        "file": "CLAUDE.md",
+        "detect": lambda cwd: True,  # always included as default
+        "entry": lambda content: "@~/.claude/skills/auto-select/SKILL.md\n",
+        "marker": "auto-select/SKILL.md",
+    },
+    {
+        "name": "cursor",
+        "file": ".cursor/rules",
+        "detect": lambda cwd: (cwd / ".cursor").exists(),
+        "entry": lambda content: content,
+        "marker": "auto-select",
+    },
+    {
+        "name": "windsurf",
+        "file": ".windsurfrules",
+        "detect": lambda cwd: (cwd / ".windsurfrules").exists(),
+        "entry": lambda content: content,
+        "marker": "auto-select",
+    },
+    {
+        "name": "copilot",
+        "file": ".github/copilot-instructions.md",
+        "detect": lambda cwd: (cwd / ".github").exists(),
+        "entry": lambda content: content,
+        "marker": "auto-select",
+    },
+    {
+        "name": "cline",
+        "file": ".clinerules",
+        "detect": lambda cwd: (cwd / ".clinerules").exists(),
+        "entry": lambda content: content,
+        "marker": "auto-select",
+    },
+]
+
 
 def skills_src() -> Path:
     return Path(__file__).parent / "skills"
@@ -51,24 +93,41 @@ def install_global() -> None:
     print(f"✓ Installed {installed} skills to {dest_root}")
 
 
+def write_agent_config(cwd: Path, agent: dict, auto_select_content: str) -> None:
+    file_path = cwd / agent["file"]
+    entry = agent["entry"](auto_select_content)
+
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if file_path.exists():
+        existing = file_path.read_text()
+        if agent["marker"] in existing:
+            print(f"  ✓ {agent['file']} already configured")
+        else:
+            with file_path.open("a") as f:
+                f.write("\n" + entry)
+            print(f"  ✓ {agent['file']} updated")
+    else:
+        file_path.write_text(entry)
+        print(f"  ✓ {agent['file']} created")
+
+
+def detect_agents(cwd: Path) -> list:
+    return [a for a in AGENTS if a["detect"](cwd)]
+
+
 def init_project(cwd: Path) -> None:
     install_global()
     print()
 
-    claude_md = cwd / "CLAUDE.md"
-    entry = "@~/.claude/skills/auto-select/SKILL.md"
+    auto_select_content = (skills_src() / "auto-select" / "SKILL.md").read_text()
+    detected = detect_agents(cwd)
 
-    if claude_md.exists():
-        existing = claude_md.read_text()
-        if "auto-select/SKILL.md" in existing:
-            print("✓ CLAUDE.md already includes auto-select")
-        else:
-            with claude_md.open("a") as f:
-                f.write("\n" + entry + "\n")
-            print("✓ Added auto-select to existing CLAUDE.md")
-    else:
-        claude_md.write_text(entry + "\n")
-        print("✓ Created CLAUDE.md")
+    print(f"Detected agents: {', '.join(a['name'] for a in detected)}")
+    print()
+
+    for agent in detected:
+        write_agent_config(cwd, agent, auto_select_content)
 
     print()
     print("AI will analyze this project and select skills automatically.")

--- a/bin/init.js
+++ b/bin/init.js
@@ -29,6 +29,51 @@ const SKILLS = [
   "auto-select",
 ];
 
+// Agent configs: each defines how to write the auto-select entry point
+// claude uses @import; others inline the skill content (no import support)
+const AGENTS = [
+  {
+    name: "claude",
+    file: "CLAUDE.md",
+    detect: () => true, // always included as default
+    write: (content) => content,
+    entry: () => "@~/.claude/skills/auto-select/SKILL.md\n",
+    marker: "auto-select/SKILL.md",
+  },
+  {
+    name: "cursor",
+    file: ".cursor/rules",
+    detect: (cwd) => fs.existsSync(path.join(cwd, ".cursor")),
+    write: (content) => content,
+    entry: (autoSelectContent) => autoSelectContent,
+    marker: "auto-select",
+  },
+  {
+    name: "windsurf",
+    file: ".windsurfrules",
+    detect: (cwd) => fs.existsSync(path.join(cwd, ".windsurfrules")),
+    write: (content) => content,
+    entry: (autoSelectContent) => autoSelectContent,
+    marker: "auto-select",
+  },
+  {
+    name: "copilot",
+    file: ".github/copilot-instructions.md",
+    detect: (cwd) => fs.existsSync(path.join(cwd, ".github")),
+    write: (content) => content,
+    entry: (autoSelectContent) => autoSelectContent,
+    marker: "auto-select",
+  },
+  {
+    name: "cline",
+    file: ".clinerules",
+    detect: (cwd) => fs.existsSync(path.join(cwd, ".clinerules")),
+    write: (content) => content,
+    entry: (autoSelectContent) => autoSelectContent,
+    marker: "auto-select",
+  },
+];
+
 function installGlobal() {
   fs.mkdirSync(SKILLS_DEST, { recursive: true });
 
@@ -48,24 +93,48 @@ function installGlobal() {
   console.log(`✓ Installed ${installed} skills to ${SKILLS_DEST}`);
 }
 
+function readAutoSelectContent() {
+  const src = path.join(SKILLS_SRC, "auto-select", "SKILL.md");
+  return fs.readFileSync(src, "utf8");
+}
+
+function writeAgentConfig(cwd, agent, autoSelectContent) {
+  const filePath = path.join(cwd, agent.file);
+  const entry = agent.entry(autoSelectContent);
+
+  // ensure parent directory exists
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+  if (fs.existsSync(filePath)) {
+    const existing = fs.readFileSync(filePath, "utf8");
+    if (existing.includes(agent.marker)) {
+      console.log(`  ✓ ${agent.file} already configured`);
+    } else {
+      fs.appendFileSync(filePath, "\n" + entry);
+      console.log(`  ✓ ${agent.file} updated`);
+    }
+  } else {
+    fs.writeFileSync(filePath, entry);
+    console.log(`  ✓ ${agent.file} created`);
+  }
+}
+
+function detectAgents(cwd) {
+  return AGENTS.filter((a) => a.detect(cwd));
+}
+
 function initProject(cwd) {
   installGlobal();
   console.log("");
 
-  const claudeMdPath = path.join(cwd, "CLAUDE.md");
-  const entry = "@~/.claude/skills/auto-select/SKILL.md";
+  const autoSelectContent = readAutoSelectContent();
+  const detected = detectAgents(cwd);
 
-  if (fs.existsSync(claudeMdPath)) {
-    const existing = fs.readFileSync(claudeMdPath, "utf8");
-    if (existing.includes("auto-select/SKILL.md")) {
-      console.log("✓ CLAUDE.md already includes auto-select");
-    } else {
-      fs.appendFileSync(claudeMdPath, "\n" + entry + "\n");
-      console.log("✓ Added auto-select to existing CLAUDE.md");
-    }
-  } else {
-    fs.writeFileSync(claudeMdPath, entry + "\n");
-    console.log("✓ Created CLAUDE.md");
+  console.log(`Detected agents: ${detected.map((a) => a.name).join(", ")}`);
+  console.log("");
+
+  for (const agent of detected) {
+    writeAgentConfig(cwd, agent, autoSelectContent);
   }
 
   console.log("");


### PR DESCRIPTION
## Summary

- `init` 실행 시 프로젝트에서 사용 중인 AI 에이전트를 자동 감지
- 각 에이전트에 맞는 설정 파일 생성 (Claude Code는 @import, 나머지는 auto-select 인라인)

## 지원 에이전트

| 에이전트 | 설정 파일 | 감지 조건 |
|---|---|---|
| Claude Code | `CLAUDE.md` | 항상 |
| Cursor | `.cursor/rules` | `.cursor/` 디렉토리 존재 |
| Windsurf | `.windsurfrules` | `.windsurfrules` 존재 |
| GitHub Copilot | `.github/copilot-instructions.md` | `.github/` 디렉토리 존재 |
| Cline | `.clinerules` | `.clinerules` 존재 |

## Example output

```
Detected agents: claude, cursor

  ✓ CLAUDE.md created
  ✓ .cursor/rules created

AI will analyze this project and select skills automatically.
```

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)